### PR TITLE
feat: update the related model when touching a relationship

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/EmbeddedBy.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbeddedBy.php
@@ -90,4 +90,16 @@ class EmbeddedBy extends BelongsTo
     {
         return $this->query->first() ?: $this->getDefaultFor($this->parent);
     }
+
+    /**
+     * Touch all of the related models for the relationship.
+     *
+     * @return void
+     */
+    public function touch()
+    {
+        $column = $this->getRelated()->getUpdatedAtColumn();
+
+        $this->update([$column => $this->getRelated()->freshTimestampString()]);
+    }
 }


### PR DESCRIPTION
@DMNSteve turns out this was simpler than I thought - the default relation behaviour is to do a `rawUpdate()` but looking at BelongsToMany it does a regular update so the model instances are kept updated, so this change is just a copy of the `touch()` method from Relation.php with `rawUpdate()` changed to `update()`