### PR TITLE
fix: return related class rather than querying for results

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/EmbeddedBy.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbeddedBy.php
@@ -88,7 +88,7 @@ class EmbeddedBy extends BelongsTo
      */
     public function getResults()
     {
-        return $this->query->first() ?: $this->getDefaultFor($this->parent);
+        return $this->related;
     }
 
     /**


### PR DESCRIPTION
@DMNSteve the previous PR didn't quite do what was required - this change ensures that the correct model gets touched when a child model is updated.