### PR TITLE
fix: return object as expected by RetryCommand

### DIFF
--- a/src/Jenssegers/Mongodb/Queue/Failed/MongoFailedJobProvider.php
+++ b/src/Jenssegers/Mongodb/Queue/Failed/MongoFailedJobProvider.php
@@ -44,7 +44,7 @@ class MongoFailedJobProvider extends DatabaseFailedJobProvider
      * Get a single failed job.
      *
      * @param  mixed $id
-     * @return array
+     * @return object
      */
     public function find($id)
     {
@@ -52,7 +52,7 @@ class MongoFailedJobProvider extends DatabaseFailedJobProvider
 
         $job['id'] = (string) $job['_id'];
 
-        return $job;
+        return (object) $job;
     }
 
     /**


### PR DESCRIPTION
RetryCommand expects `$job` to be an object

https://github.com/laravel/framework/blob/6a8ab1356b5497c7a15f6d12c682e5a53409df77/src/Illuminate/Queue/Console/RetryCommand.php#L68-L73