### PR TITLE
fix: always assume '_id'

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -200,7 +200,7 @@ class Builder extends BaseBuilder
      */
     public function find($id, $columns = [])
     {
-        return $this->where($this->getKeyName(), '=', $this->convertKey($id))->first($columns);
+        return $this->where('_id', '=', $this->convertKey($id))->first($columns);
     }
 
     /**


### PR DESCRIPTION
@StevePorter92 I'm sure I remember doing this already, but it's not there.

`getKeyName()` only exists when `$this` is a Model, so it fails when doing table::find(), eg in designmynight/collins-api#632