### PR TITLE
fix: call $this->asDateTime() so method can be overridden

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -81,7 +81,7 @@ abstract class Model extends BaseModel
 
         // Let Eloquent convert the value to a DateTime instance.
         if (!$value instanceof DateTime) {
-            $value = parent::asDateTime($value);
+            $value = $this->asDateTime($value);
         }
 
         return new UTCDateTime($value->getTimestamp() * 1000);


### PR DESCRIPTION
We use a base Model class that extends the Mongodb Model class so our inheritance looks like this:
```
Illuminate\Database\Eloquent\Model
  -> Jenssegers\Mongodb\Eloquent\Model
      -> App\Models\Model
```

Our extended Model class overrides `asDateTime()` but when creating a new model like `new Model([ ... attrs ... ])` any dates would be handled with the MongoDb Model's `fromDateTime()` method, and calling `parent::asDateTime()` from there passes control up to the Eloquent Model rather than invoking the overridden method in our Model class.